### PR TITLE
Added support for Offline Dead Letters Queues

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,7 +8,7 @@ const { readdir, unlink } = require("fs"),
     execAsync = require("util").promisify(exec),
     DEFAULT_IN_PATH = "cf-templates",
     DEFAULT_OUT_PATH = "resources",
-    SQS_DEAD_LETTER_PREFIX = "DL";
+    SQS_DEAD_LETTER_PREFIX = "DL",
     S3_PREFIX = "serverless-translate-templateurls";
 
 /**


### PR DESCRIPTION
Hi there @cjuega,

Here is a simple solution for offline management of SQS queues that also have DeadLetters Queue associated with them.

I would like you to tell me what you think and which do you think of the two possible changes that I propose below, which is the one that you think is more correct.

I have tested this in a simple project that only loads `serverless-translate-templateurls`, `serverless-offline` and `serverless-offline-sqs` and the queues are correctly exposed in the two proposed ways and messages can be sent.

Thx! :D